### PR TITLE
商品購入確認ページの実装

### DIFF
--- a/app/assets/stylesheets/buy.scss
+++ b/app/assets/stylesheets/buy.scss
@@ -1,0 +1,85 @@
+.main{
+  &__content{
+    &__title{
+      font-size: 22px;
+      font-weight: 600;
+      padding: 32px;
+      display: block;
+      text-align: center;
+      border-bottom: $border-width $border-color solid;
+    }
+    &__item{
+      padding: 32px 16px;
+      border-bottom: $border-width $border-color solid;
+      &__inner{
+        max-width: 340px;
+        margin: 0 auto;
+        &__box{
+          display: flex;
+          &__img{
+            height: 80px;
+            width: 80px;
+          }
+          &__detail{
+            margin-left: 16px;
+            &__item-name{
+              font-size: $text-base;
+              padding-bottom: 8px;
+            }
+            &__bold{
+              font-weight: 600;
+              font-size: 12px;
+            }
+          }
+        }
+      }
+    }
+    &__buy{
+      padding: 32px 16px;
+      padding-bottom: 48px;
+      &__inner{
+        max-width: 340px;
+        margin: 0 auto;
+        &__price{
+          padding-bottom: 16px;
+          @include display-flex(space-between);
+          border-bottom: $border-width $border-color solid;
+          &__text{
+            font-size: 18px;
+            font-weight: 600;
+            line-height: 42px;
+          }
+          &__int{
+            font-size: 28px;
+            font-weight: 600;
+          }
+        }
+        &__section{
+          padding: 32px 0;
+          border-bottom: $border-width $border-color solid;
+          &__div{
+            h {
+              display: block;
+              @include label-font(black)
+            }
+            a {
+              color: $main-color;
+              font-size: $text-base;
+            }
+            &__address{
+              margin-top: 8px;
+              p{
+                font-size: $text-base;
+              }
+            }
+          }
+        }
+        &__btn{
+          @include btn($btn-required-grey);
+          color: #fff;
+          margin-top: 32px;;
+        }
+      }
+    }
+  }
+}

--- a/app/views/buy.html.haml
+++ b/app/views/buy.html.haml
@@ -1,0 +1,45 @@
+.wrapper
+  = render 'partial/new-header'
+
+  .main
+    .main__content
+      %h.main__content__title
+        購入内容の確認
+      %section.main__content__item
+        .main__content__item__inner
+          .main__content__item__inner__box
+            %h.main__content__item__inner__box__img
+              = image_tag 'item.jpg', :size =>'80x80', alt: 'img'
+            .main__content__item__inner__box__detail
+              %p.main__content__item__inner__box__detail__item-name
+                ★新品・未使用★LUOTEEMI E16042611R ファッションピアス
+              %p.main__content__item__inner__box__detail__bold
+                %span ¥1,180
+                %span （税込）送料込み
+      %section.main__content__buy
+        .main__content__buy__inner
+          .main__content__buy__inner__price
+            .main__content__buy__inner__price__text
+              支払い金額
+            .main__content__buy__inner__price__int
+              ¥1,180
+          %section.main__content__buy__inner__section
+            .main__content__buy__inner__section__div
+              %h 支払い方法
+              = link_to "#" , class:"main__content__buy__inner__section__div__link" do
+                %i.fas.fa-plus-circle
+                  登録してください
+          %section.main__content__buy__inner__section
+            .main__content__buy__inner__section__div
+              %h 配送先
+              .main__content__buy__inner__section__div__address
+                %p 179-0074
+                %p 東京都練馬区春日町１−２−３
+                %p 山田 太郎
+              = link_to "#" do
+                変更する
+          .main__content__buy__inner__btn
+            %button{type: "submit", class:"main__content__buy__inner__btn"}
+              購入する
+
+  = render 'partial/new-footer'


### PR DESCRIPTION
# What

アプリケーションの商品購入確認画面のビューを作成
購入する商品が明確になるような見た目になっている

# Why

アプリにおいて商品購入の確認画面は必須のビューなので追加


<a href="https://gyazo.com/f1e9682ea52ee7a8803a28c719e79e8c"><img src="https://i.gyazo.com/f1e9682ea52ee7a8803a28c719e79e8c.png" alt="Image from Gyazo" width="1680"/></a>