### PR TITLE
商品削除

### DIFF
--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -49,3 +49,14 @@ $(document).on('turbolinks:load', ()=> {
     if ($('.js-file').length == 0) $('#image-box').append(buildFileField(fileIndex[0]));
   });
 });
+
+//item詳細ページの画面表示
+$(function () {
+  $(".itembox__body__image__sub__thumb").first().addClass("active");
+  $(".itembox__body__image__sub__thumb__photo").click(function () { 
+    image_url = $(this).attr("src");
+    $(".itembox__body__image__main__photo").attr("src", image_url).hide().fadeIn();
+    $(".itembox__body__image__sub__thumb.active").removeClass("active");
+    $(this).parent().addClass("active"); 
+  });
+});

--- a/app/assets/javascripts/itme.js
+++ b/app/assets/javascripts/itme.js
@@ -1,9 +1,0 @@
-$(function () {
-  $(".itembox__body__image__sub__thumb").first().addClass("active"); // 1枚目の小画像をアクティブに変更
-  $(".itembox__body__image__sub__thumb__photo").click(function () { // 小画像がクリックされたらイベント発火
-    image_url = $(this).attr("src"); // クリックされた画像のPATHを取得
-    $(".itembox__body__image__main__photo").attr("src", image_url).hide().fadeIn(); // メイン画像をクリックされた画像に変更
-    $(".itembox__body__image__sub__thumb.active").removeClass("active"); // 1枚目の小画像のアクティブを無効化
-    $(this).parent().addClass("active"); // クリックされた小画像をアクティブに変更
-  });
-});

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -62,6 +62,7 @@ class ItemsController < ApplicationController
     respond_to do |format|
       format.html { redirect_to items_url, notice: 'Item was successfully destroyed.' }
       format.json { head :no_content }
+      
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -58,7 +58,7 @@ class ItemsController < ApplicationController
   # DELETE /items/1
   # DELETE /items/1.json
   def destroy
-    @item.destroy
+    @item.destroy  if user_signed_in? && current_user.id == @item.seller_id
     respond_to do |format|
       format.html { redirect_to items_url, notice: 'Item was successfully destroyed.' }
       format.json { head :no_content }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
-  belongs_to :brand
+  belongs_to :brand, dependent: :destroy
   belongs_to :category, optional: true
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true


### PR DESCRIPTION
＃What
商品削除(投稿者のみが削除できるようにした)
商品が削除されるとそれに紐づくブランドテーブル、イメージテーブルのデータも消えるようにした。
#Why
商品削除機能を実装のため。