### PR TITLE
購入内容の確認ページのサーバサイド(クレジット関係以外)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,3 +8,4 @@
 @import "modules/items-sell";
 @import "modules/user";
 @import "modules/show-item";
+@import "modules/buy"

--- a/app/assets/stylesheets/modules/_buy.scss
+++ b/app/assets/stylesheets/modules/_buy.scss
@@ -1,5 +1,6 @@
 .main{
   &__content{
+    height: 100%;
     &__title{
       font-size: 22px;
       font-weight: 600;
@@ -9,6 +10,7 @@
       border-bottom: $border-width $border-color solid;
     }
     &__item{
+      height: 200px;
       padding: 32px 16px;
       border-bottom: $border-width $border-color solid;
       &__inner{
@@ -16,12 +18,14 @@
         margin: 0 auto;
         &__box{
           display: flex;
+          justify-content: space-between;
           &__img{
-            height: 80px;
-            width: 80px;
+            margin-right:16px ;
+            line-height: 200px;
           }
           &__detail{
             margin-left: 16px;
+            width: 100%;
             &__item-name{
               font-size: $text-base;
               padding-bottom: 8px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:show, :edit, :update,  :buy, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :buy, :destroy]
   before_action :set_parent, only: [:new, :create]
 
   # GET /items
@@ -30,7 +30,7 @@ class ItemsController < ApplicationController
   end
 
   def buy
-
+    @address = Address.find(current_user.id)
   end
 
   # POST /items

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update,  :buy, :destroy]
   before_action :set_parent, only: [:new, :create]
 
   # GET /items
@@ -26,6 +26,10 @@ class ItemsController < ApplicationController
   # GET /items/1/edit
   def edit
     @item = Item.find(params[:id])
+
+  end
+
+  def buy
 
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, only: [:buy]
   before_action :set_item, only: [:show, :edit, :update, :buy, :destroy]
   before_action :set_parent, only: [:new, :create]
+
 
   # GET /items
   # GET /items.json

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,2 +1,28 @@
 module ItemsHelper
+  
+  # 円マーク値段
+  def enmark_item_price(item)
+    "¥#{item.price}"  
+  end
+
+  #  郵便番号にハイフン
+  def user_post_code(address)
+     address.postal_code.to_s.insert(3, "-")
+  end
+
+  # 都道府県から番地をまとめ、ビル名があれば表示
+  def user_address_info(address)
+    if address.building.blank?
+      address.prefecture + address.city + address.block
+    else
+     str = "#{address.prefecture}#{address.city}#{address.block}\n#{address.building}"
+      str.chomp
+    end
+  end
+
+  #ユーザーのフルネーム
+  def user_full_name(address)
+    address.send_first_name+address.send_name
+  end
+  
 end

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -9,20 +9,21 @@
         .main__content__item__inner
           .main__content__item__inner__box
             %h.main__content__item__inner__box__img
-              = image_tag 'item.jpg', :size =>'80x80', alt: 'img'
+              - @item.images.first(1).each do |image|
+                = image_tag image.url.to_s,  size:'130x130'
             .main__content__item__inner__box__detail
               %p.main__content__item__inner__box__detail__item-name
-                ★新品・未使用★LUOTEEMI E16042611R ファッションピアス
+                = @item.name
               %p.main__content__item__inner__box__detail__bold
-                %span ¥1,180
-                %span （税込）送料込み
+                = "¥#{@item.price}"
+              %span （税込）送料込み
       %section.main__content__buy
         .main__content__buy__inner
           .main__content__buy__inner__price
             .main__content__buy__inner__price__text
               支払い金額
             .main__content__buy__inner__price__int
-              ¥1,180
+              = @item.price
           %section.main__content__buy__inner__section
             .main__content__buy__inner__section__div
               %h 支払い方法

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -15,7 +15,7 @@
               %p.main__content__item__inner__box__detail__item-name
                 = @item.name
               %p.main__content__item__inner__box__detail__bold
-                = "¥#{@item.price}"
+                = enmark_item_price(@item)
               %span （税込）送料込み
       %section.main__content__buy
         .main__content__buy__inner
@@ -23,7 +23,7 @@
             .main__content__buy__inner__price__text
               支払い金額
             .main__content__buy__inner__price__int
-              = @item.price
+              = enmark_item_price(@item)
           %section.main__content__buy__inner__section
             .main__content__buy__inner__section__div
               %h 支払い方法
@@ -34,11 +34,11 @@
             .main__content__buy__inner__section__div
               %h 配送先
               .main__content__buy__inner__section__div__address
-                %p 179-0074
-                %p 東京都練馬区春日町１−２−３
-                %p 山田 太郎
-              = link_to "#" do
-                変更する
+                = user_post_code(@address)
+                %br
+                = safe_join(user_address_info(@address).split("\n"),tag(:br))
+                %br
+                = user_full_name(@address)
           .main__content__buy__inner__btn
             %button{type: "submit", class:"main__content__buy__inner__btn"}
               購入する

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -81,6 +81,6 @@
                 削除
         - else
           .itembox__btns__contents-btn__seller-menu__buy
-            = link_to "購入", "#"
+            = link_to "購入", buy_item_path(@item)
               
 = render "footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,5 @@ Rails.application.routes.draw do
   root 'items#index'
   resources :user
   resources :items do
-    member do
-      get :buy
-    end
-  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,9 @@ Rails.application.routes.draw do
   end
   root 'items#index'
   resources :user
-  resources :items
+  resources :items do
+    member do
+      get :buy
+    end
+  end
 end


### PR DESCRIPTION
#クレジット関係、購入機能は後日
# what
- ルーティングとコントローラーにbuyを追加
- 商品詳細ページの購入ボタンを押すと確認ページにいく
- ログインしていない,会員登録していないユーザーはログインページにいく
- 購入商品の情報(商品名,値段,画像1枚)の表示
- 購入者の送付先情報

# why
商品を購入する最終確認のページを作成した。

<a href="https://gyazo.com/415ea1e2e4a1ffcab888e3d0124220af"><img src="https://i.gyazo.com/415ea1e2e4a1ffcab888e3d0124220af.png" alt="Image from Gyazo" width="350"/></a>
